### PR TITLE
Single repository replication config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/atlassian/terraform-provider-artifactory
 
 require (
-	github.com/atlassian/go-artifactory/v2 v2.3.0
+	github.com/atlassian/go-artifactory/v2 v2.4.0
 	github.com/hashicorp/terraform v0.11.13
 )

--- a/pkg/artifactory/provider.go
+++ b/pkg/artifactory/provider.go
@@ -59,13 +59,14 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"artifactory_local_repository":   resourceArtifactoryLocalRepository(),
-			"artifactory_remote_repository":  resourceArtifactoryRemoteRepository(),
-			"artifactory_virtual_repository": resourceArtifactoryVirtualRepository(),
-			"artifactory_group":              resourceArtifactoryGroup(),
-			"artifactory_user":               resourceArtifactoryUser(),
-			"artifactory_permission_target":  resourceArtifactoryPermissionTarget(),
-			"artifactory_replication_config": resourceArtifactoryReplicationConfig(),
+			"artifactory_local_repository":          resourceArtifactoryLocalRepository(),
+			"artifactory_remote_repository":         resourceArtifactoryRemoteRepository(),
+			"artifactory_virtual_repository":        resourceArtifactoryVirtualRepository(),
+			"artifactory_group":                     resourceArtifactoryGroup(),
+			"artifactory_user":                      resourceArtifactoryUser(),
+			"artifactory_permission_target":         resourceArtifactoryPermissionTarget(),
+			"artifactory_replication_config":        resourceArtifactoryReplicationConfig(),
+			"artifactory_single_replication_config": resourceArtifactorySingleReplicationConfig(),
 			// Deprecated. Remove in V3
 			"artifactory_permission_targets": resourceArtifactoryPermissionTargets(),
 		},

--- a/pkg/artifactory/resource_artifactory_single_replication_config.go
+++ b/pkg/artifactory/resource_artifactory_single_replication_config.go
@@ -1,0 +1,223 @@
+package artifactory
+
+import (
+	"context"
+	"fmt"
+	"github.com/atlassian/go-artifactory/v2/artifactory"
+	"github.com/atlassian/go-artifactory/v2/artifactory/v1"
+	"github.com/hashicorp/terraform/helper/schema"
+	"net/http"
+)
+
+func resourceArtifactorySingleReplicationConfig() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSingleReplicationConfigCreate,
+		Read:   resourceSingleReplicationConfigRead,
+		Update: resourceSingleReplicationConfigUpdate,
+		Delete: resourceSingleReplicationConfigDelete,
+		Exists: resourceSingleReplicationConfigExists,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"repo_key": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"cron_exp": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enable_event_replication": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"url": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"socket_timeout_millis": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  15000,
+			},
+			"username": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"password": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+				StateFunc: getMD5Hash,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"sync_deletes": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"sync_properties": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"sync_statistics": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"path_prefix": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func unpackSingleReplicationConfig(s *schema.ResourceData) *v1.SingleReplicationConfig {
+	d := &ResourceData{s}
+	replicationConfig := new(v1.SingleReplicationConfig)
+
+	replicationConfig.RepoKey = d.getStringRef("repo_key")
+	replicationConfig.CronExp = d.getStringRef("cron_exp")
+	replicationConfig.EnableEventReplication = d.getBoolRef("enable_event_replication")
+	replicationConfig.URL = d.getStringRef("url")
+	replicationConfig.SocketTimeoutMillis = d.getIntRef("socket_timeout_millis")
+	replicationConfig.Username = d.getStringRef("username")
+	replicationConfig.Enabled = d.getBoolRef("enabled")
+	replicationConfig.SyncDeletes = d.getBoolRef("sync_deletes")
+	replicationConfig.SyncProperties = d.getBoolRef("sync_properties")
+	replicationConfig.SyncStatistics = d.getBoolRef("sync_statistics")
+	replicationConfig.PathPrefix = d.getStringRef("path_prefix")
+	replicationConfig.Password = d.getStringRef("password")
+
+	return replicationConfig
+}
+
+func packSingleReplicationConfig(replicationConfig *v1.ReplicationConfig, d *schema.ResourceData) error {
+	hasErr := false
+	logErr := cascadingErr(&hasErr)
+
+	logErr(d.Set("repo_key", replicationConfig.RepoKey))
+	logErr(d.Set("cron_exp", replicationConfig.CronExp))
+	logErr(d.Set("enable_event_replication", replicationConfig.EnableEventReplication))
+
+	firstConfig := (*replicationConfig.Replications)[0]
+
+	if firstConfig.URL != nil {
+		logErr(d.Set("url", *firstConfig.URL))
+	}
+
+	if firstConfig.SocketTimeoutMillis != nil {
+		logErr(d.Set("socket_timeout_millis", *firstConfig.SocketTimeoutMillis))
+	}
+
+	if firstConfig.Username != nil {
+		logErr(d.Set("username", *firstConfig.Username))
+	}
+
+	if firstConfig.Password != nil {
+		logErr(d.Set("password", getMD5Hash(*firstConfig.Password)))
+	}
+
+	if firstConfig.Enabled != nil {
+		logErr(d.Set("enabled", *firstConfig.Enabled))
+	}
+
+	if firstConfig.SyncDeletes != nil {
+		logErr(d.Set("sync_deletes", *firstConfig.SyncDeletes))
+	}
+
+	if firstConfig.SyncProperties != nil {
+		logErr(d.Set("sync_properties", *firstConfig.SyncProperties))
+	}
+
+	if firstConfig.SyncStatistics != nil {
+		logErr(d.Set("sync_statistics", *firstConfig.SyncStatistics))
+	}
+
+	if firstConfig.PathPrefix != nil {
+		logErr(d.Set("path_prefix", *firstConfig.PathPrefix))
+	}
+
+	if hasErr {
+		return fmt.Errorf("failed to pack replication config")
+	}
+
+	return nil
+}
+
+func resourceSingleReplicationConfigCreate(d *schema.ResourceData, m interface{}) error {
+	c := m.(*artifactory.Artifactory)
+
+	replicationConfig := unpackSingleReplicationConfig(d)
+
+	_, err := c.V1.Artifacts.SetSingleRepositoryReplicationConfig(context.Background(), *replicationConfig.RepoKey, replicationConfig)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(*replicationConfig.RepoKey)
+	return resourceSingleReplicationConfigRead(d, m)
+}
+
+func resourceSingleReplicationConfigRead(d *schema.ResourceData, m interface{}) error {
+	c := m.(*artifactory.Artifactory)
+
+	replicationConfig, _, err := c.V1.Artifacts.GetRepositoryReplicationConfig(context.Background(), d.Id())
+
+	if err != nil {
+		return err
+	} else if len(*replicationConfig.Replications) > 1 {
+		return fmt.Errorf("resource_single_replication_config does not support multiple replication config on a repo. Use resource_artifactory_replication_config instead")
+	}
+
+	return packSingleReplicationConfig(replicationConfig, d)
+}
+
+func resourceSingleReplicationConfigUpdate(d *schema.ResourceData, m interface{}) error {
+	c := m.(*artifactory.Artifactory)
+
+	replicationConfig := unpackSingleReplicationConfig(d)
+	_, err := c.V1.Artifacts.UpdateSingleRepositoryReplicationConfig(context.Background(), d.Id(), replicationConfig)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(*replicationConfig.RepoKey)
+
+	return resourceSingleReplicationConfigRead(d, m)
+}
+
+func resourceSingleReplicationConfigDelete(d *schema.ResourceData, m interface{}) error {
+	c := m.(*artifactory.Artifactory)
+	replicationConfig := unpackSingleReplicationConfig(d)
+	_, err := c.V1.Artifacts.DeleteRepositoryReplicationConfig(context.Background(), *replicationConfig.RepoKey)
+	return err
+}
+
+func resourceSingleReplicationConfigExists(d *schema.ResourceData, m interface{}) (bool, error) {
+	c := m.(*artifactory.Artifactory)
+
+	replicationName := d.Id()
+	replicationConfig, resp, err := c.V1.Artifacts.GetRepositoryReplicationConfig(context.Background(), replicationName)
+
+	if resp.StatusCode == http.StatusNotFound {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	} else if len(*replicationConfig.Replications) > 1 {
+		return false, fmt.Errorf("resource_single_replication_config does not support multiple replication config on a repo. Use resource_artifactory_replication_config instead")
+	}
+
+	return true, nil
+}

--- a/pkg/artifactory/resource_artifactory_single_replication_config.go
+++ b/pkg/artifactory/resource_artifactory_single_replication_config.go
@@ -33,7 +33,7 @@ func resourceArtifactorySingleReplicationConfig() *schema.Resource {
 			"enable_event_replication": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
+				Computed: true,
 			},
 			"url": {
 				Type:     schema.TypeString,
@@ -43,7 +43,7 @@ func resourceArtifactorySingleReplicationConfig() *schema.Resource {
 			"socket_timeout_millis": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  15000,
+				Computed: true,
 			},
 			"username": {
 				Type:     schema.TypeString,
@@ -58,22 +58,22 @@ func resourceArtifactorySingleReplicationConfig() *schema.Resource {
 			"enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
+				Computed: true,
 			},
 			"sync_deletes": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
+				Computed: true,
 			},
 			"sync_properties": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
+				Computed: true,
 			},
 			"sync_statistics": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
+				Computed: true,
 			},
 			"path_prefix": {
 				Type:     schema.TypeString,

--- a/pkg/artifactory/resource_artifactory_single_replication_config.go
+++ b/pkg/artifactory/resource_artifactory_single_replication_config.go
@@ -37,7 +37,7 @@ func resourceArtifactorySingleReplicationConfig() *schema.Resource {
 			},
 			"url": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 			"socket_timeout_millis": {

--- a/pkg/artifactory/resource_artifactory_single_replication_config.go
+++ b/pkg/artifactory/resource_artifactory_single_replication_config.go
@@ -87,18 +87,18 @@ func unpackSingleReplicationConfig(s *schema.ResourceData) *v1.SingleReplication
 	d := &ResourceData{s}
 	replicationConfig := new(v1.SingleReplicationConfig)
 
-	replicationConfig.RepoKey = d.getStringRef("repo_key")
-	replicationConfig.CronExp = d.getStringRef("cron_exp")
-	replicationConfig.EnableEventReplication = d.getBoolRef("enable_event_replication")
-	replicationConfig.URL = d.getStringRef("url")
-	replicationConfig.SocketTimeoutMillis = d.getIntRef("socket_timeout_millis")
-	replicationConfig.Username = d.getStringRef("username")
-	replicationConfig.Enabled = d.getBoolRef("enabled")
-	replicationConfig.SyncDeletes = d.getBoolRef("sync_deletes")
-	replicationConfig.SyncProperties = d.getBoolRef("sync_properties")
-	replicationConfig.SyncStatistics = d.getBoolRef("sync_statistics")
-	replicationConfig.PathPrefix = d.getStringRef("path_prefix")
-	replicationConfig.Password = d.getStringRef("password")
+	replicationConfig.RepoKey = d.getStringRef("repo_key", false)
+	replicationConfig.CronExp = d.getStringRef("cron_exp", false)
+	replicationConfig.EnableEventReplication = d.getBoolRef("enable_event_replication", false)
+	replicationConfig.URL = d.getStringRef("url", false)
+	replicationConfig.SocketTimeoutMillis = d.getIntRef("socket_timeout_millis", false)
+	replicationConfig.Username = d.getStringRef("username", false)
+	replicationConfig.Enabled = d.getBoolRef("enabled", false)
+	replicationConfig.SyncDeletes = d.getBoolRef("sync_deletes", false)
+	replicationConfig.SyncProperties = d.getBoolRef("sync_properties", false)
+	replicationConfig.SyncStatistics = d.getBoolRef("sync_statistics", false)
+	replicationConfig.PathPrefix = d.getStringRef("path_prefix", false)
+	replicationConfig.Password = d.getStringRef("password", false)
 
 	return replicationConfig
 }

--- a/pkg/artifactory/resource_artifactory_single_replication_config_test.go
+++ b/pkg/artifactory/resource_artifactory_single_replication_config_test.go
@@ -1,0 +1,75 @@
+package artifactory
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/atlassian/go-artifactory/v2/artifactory"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+const singleReplicationConfigTemplate = `
+resource "artifactory_local_repository" "lib-local" {
+	key = "lib-local"
+	package_type = "maven"
+}
+
+resource "artifactory_single_replication_config" "lib-local" {
+	repo_key = "${artifactory_local_repository.lib-local.key}"
+	cron_exp = "0 0 * * * ?"
+	enable_event_replication = true
+	url = "%s"
+	username = "%s"
+	password = "%s"
+}
+`
+
+func TestAccSingleReplication_full(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		CheckDestroy: testAccCheckSingleReplicationDestroy("artifactory_single_replication_config.lib-local"),
+		Providers:    testAccProviders,
+
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(
+					singleReplicationConfigTemplate,
+					os.Getenv("ARTIFACTORY_URL"),
+					os.Getenv("ARTIFACTORY_USERNAME"),
+					os.Getenv("ARTIFACTORY_PASSWORD"),
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("artifactory_single_replication_config.lib-local", "repo_key", "lib-local"),
+					resource.TestCheckResourceAttr("artifactory_single_replication_config.lib-local", "cron_exp", "0 0 * * * ?"),
+					resource.TestCheckResourceAttr("artifactory_single_replication_config.lib-local", "enable_event_replication", "true"),
+					resource.TestCheckResourceAttr("artifactory_single_replication_config.lib-local", "url", os.Getenv("ARTIFACTORY_URL")),
+					resource.TestCheckResourceAttr("artifactory_single_replication_config.lib-local", "username", os.Getenv("ARTIFACTORY_USERNAME")),
+					resource.TestCheckResourceAttr("artifactory_single_replication_config.lib-local", "password", os.Getenv("ARTIFACTORY_PASSWORD")),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckSingleReplicationDestroy(id string) func(*terraform.State) error {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*artifactory.Artifactory)
+		rs, ok := s.RootModule().Resources[id]
+		if !ok {
+			return fmt.Errorf("err: Resource id[%s] not found", id)
+		}
+
+		replica, resp, err := client.V1.Artifacts.GetRepositoryReplicationConfig(context.Background(), rs.Primary.ID)
+
+		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusBadRequest {
+			return nil
+		} else if err != nil {
+			return fmt.Errorf("error: Request failed: %s", err.Error())
+		} else {
+			return fmt.Errorf("error: Replication %s still exists", replica)
+		}
+	}
+}

--- a/website/artifactory.erb
+++ b/website/artifactory.erb
@@ -28,6 +28,9 @@
               <li<%= sidebar_current("docs-artifactory-resource-replication-config") %>>
                 <a href="/docs/providers/artifactory/r/artifactory_replication_config.html">artifactory_replication_config</a>
               </li>
+              <li<%= sidebar_current("docs-artifactory-resource-single-replication-config") %>>
+                <a href="/docs/providers/artifactory/r/artifactory_replication_config.html">artifactory_replication_config</a>
+              </li>
               <li<%= sidebar_current("docs-artifactory-resource-user") %>>
                 <a href="/docs/providers/artifactory/r/artifactory_user.html">artifactory_user</a>
               </li>

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -19,6 +19,7 @@ with the proper credentials before it can be used.
     * [Local Repositories](./r/artifactory_local_repository.html.markdown)
     * [Remote Repositories](./r/artifactory_remote_repository.html.markdown)
     * [Replication Configurations](./r/artifactory_replication_config.html.markdown)
+    * [Single Replication Configurations](./r/artifactory_single_replication_config.html.markdown)
     * [Virtual Repositories](./r/artifactory_virtual_repository.html.markdown)
 
 - Deprecated Resources

--- a/website/docs/r/artifactory_single_replication_config.html.markdown
+++ b/website/docs/r/artifactory_single_replication_config.html.markdown
@@ -1,0 +1,76 @@
+---
+layout: "artifactory"
+page_title: "Artifactory: artifactory_single_replication_config"
+sidebar_current: "docs-artifactory-resource-single-replication-config"
+description: |-
+  Provides a single replication config resource.
+---
+
+# artifactory_single_replication_config
+
+Provides an Artifactory single replication config resource. This can be used to create and manage a single Artifactory
+replication. Primarily used when pull replication is needed.
+
+**WARNING: This should not be used on a repository with `artifactory_replication_config`. Using both together will cause
+unexpected behaviour and will almost certainly cause your replications to break.**
+
+### Passwords
+Passwords can only be used when encryption is turned off (https://www.jfrog.com/confluence/display/RTF/Artifactory+Key+Encryption). 
+Since only the artifactory server can decrypt them it is impossible for terraform to diff changes correctly.
+
+To get full management, passwords can be decrypted globally using `POST /api/system/decrypt`. If this is not possible, 
+the password diff can be disabled per resource with-- noting that this will require resources to be tainted for an update:
+```hcl
+lifecycle {
+    ignore_changes = ["password"]
+}
+``` 
+
+## Example Usage
+
+```hcl
+# Create a replication between two artifactory local repositories
+resource "artifactory_local_repository" "provider_test_source" {
+	key = "provider_test_source"
+	package_type = "maven"
+}
+
+resource "artifactory_local_repository" "provider_test_dest" {
+	key = "provider_test_dest"
+	package_type = "maven"
+}
+
+resource "artifactory_single_replication_config" "foo-rep" {
+	repo_key = "${artifactory_local_repository.provider_test_source.key}"
+	cron_exp = "0 0 * * * ?"
+	enable_event_replication = true
+    url = "${var.artifactory_url}"
+    username = "${var.artifactory_username}"
+    password = "${var.artifactory_password}"		
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `repo_key` - (Required)
+* `cron_exp` - (Required)
+* `enable_event_replication` - (Optional)
+* `url` - (Required)
+* `socket_timeout_millis` - (Optional)
+* `username` - (Optional)
+* `password` - (Optional) Requires password encryption to be turned off `POST /api/system/decrypt`
+* `enabled` - (Optional)
+* `sync_deletes` - (Optional)
+* `sync_properties` - (Optional)
+* `sync_statistics` - (Optional)
+* `path_prefix` - (Optional)
+
+## Import
+
+Replication configs can be imported using their repo key, e.g.
+
+```
+$ terraform import artifactory_single_replication_config.foo-rep repository-key
+```


### PR DESCRIPTION
Allows for a single replication to be added to a repository. This is useful if you only have a Pro licence and/or you need pull replication.

This should close #28 but requires atlassian/go-artifactory#15 so that the referenced modules can be updated.

As a side note, I've called this `artifactory_single_replication_config`, but it feels like it really should be `artifactory_replication_config`, while the currentl `artifactory_replication_config` should become `artifactory_multi_replication_config`. Most I think this would be more beneficial as you're more likely to have a pro licence for single replication than an enterprise for multi replication