### PR TITLE
Retry logic added to user create

### DIFF
--- a/pkg/artifactory/resource_artifactory_user.go
+++ b/pkg/artifactory/resource_artifactory_user.go
@@ -144,7 +144,7 @@ func resourceUserCreate(d *schema.ResourceData, m interface{}) error {
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
-			return resource.RetryableError(fmt.Errorf("expected permission target to be created, but currently not found"))
+			return resource.RetryableError(fmt.Errorf("expected user to be created, but currently not found"))
 		}
 
 		return resource.NonRetryableError(resourceUserRead(d, m))


### PR DESCRIPTION
When creating a user on a HA cluster, it is sometimes possible that the read after create hits a different instance to the create request. In this case the provider fails, yet the resource is created.

This used the inbuilt retry logic to keep trying until the create has been successfully read.

Related to #45, #41 