### PR TITLE
Resource artifactory virtual repository update fix

### DIFF
--- a/pkg/artifactory/resource_artifactory_virtual_repository_test.go
+++ b/pkg/artifactory/resource_artifactory_virtual_repository_test.go
@@ -38,6 +38,53 @@ func TestAccVirtualRepository_basic(t *testing.T) {
 	})
 }
 
+const virtualRepositoryUpdateBefore = `
+resource "artifactory_virtual_repository" "foo" {
+	key          = "foo"
+	description  = "Before"
+	package_type = "maven"
+	repositories = []
+}
+`
+
+const virtualRepositoryUpdateAfter = `
+resource "artifactory_virtual_repository" "foo" {
+	key          = "foo"
+	description  = "After"
+	package_type = "maven"
+	repositories = []
+}
+`
+
+func TestAccVirtualRepository_update(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckVirtualRepositoryDestroy("artifactory_virtual_repository.foo"),
+		Providers:    testAccProviders,
+
+		Steps: []resource.TestStep{
+			{
+				Config: virtualRepositoryUpdateBefore,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("artifactory_virtual_repository.foo", "key", "foo"),
+					resource.TestCheckResourceAttr("artifactory_virtual_repository.foo", "description", "Before"),
+					resource.TestCheckResourceAttr("artifactory_virtual_repository.foo", "package_type", "maven"),
+					resource.TestCheckResourceAttr("artifactory_virtual_repository.foo", "repositories.#", "0"),
+				),
+			},
+			{
+				Config: virtualRepositoryUpdateAfter,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("artifactory_virtual_repository.foo", "key", "foo"),
+					resource.TestCheckResourceAttr("artifactory_virtual_repository.foo", "description", "After"),
+					resource.TestCheckResourceAttr("artifactory_virtual_repository.foo", "package_type", "maven"),
+					resource.TestCheckResourceAttr("artifactory_virtual_repository.foo", "repositories.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 const virtualRepositoryFull = `
 resource "artifactory_virtual_repository" "foo" {
 	key = "foo"

--- a/pkg/artifactory/util.go
+++ b/pkg/artifactory/util.go
@@ -12,7 +12,7 @@ import (
 type ResourceData struct{ *schema.ResourceData }
 
 func (d *ResourceData) getStringRef(key string, onlyIfChanged bool) *string {
-	if v, ok := d.GetOkExists(key); ok && (!onlyIfChanged || d.HasChange(key)) {
+	if v, ok := d.GetOk(key); ok && (!onlyIfChanged || d.HasChange(key)) {
 		return artifactory.String(v.(string))
 	}
 	return nil


### PR DESCRIPTION
Fixes #49 

This PR fixes bug causing 400 errors when attempting to update a `resource_artifactory_virtual_repository` resource without having the `repo_layout_ref` attribute set.

The use of `GetOkExists` in the `getStringRef` function was causing issues due to it not checking the `Zero` function for the string type resulting strings always being ok even when empty. This resulted in the request to the Artifactory API always having `repoLayoutRef` set to an empty string which caused a 400.

## References:
- GetOkExists documentation: https://github.com/hashicorp/terraform/blob/master/helper/schema/resource_data.go#L111
- GetOk documentation: https://github.com/hashicorp/terraform/blob/master/helper/schema/resource_data.go#L88