### PR TITLE
Add virtual_retrieval_cache_period_seconds paramter to virtual repository resource.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Fetch the dependencies
-FROM golang:1.12-alpine AS builder
+FROM golang:1.13-alpine AS builder
 
 RUN apk add --update ca-certificates git gcc g++ libc-dev
 WORKDIR /src/

--- a/pkg/artifactory/resource_artifactory_virtual_repository.go
+++ b/pkg/artifactory/resource_artifactory_virtual_repository.go
@@ -67,6 +67,11 @@ func resourceArtifactoryVirtualRepository() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"virtual_retrieval_cache_period_seconds": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
 			"key_pair": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -96,6 +101,7 @@ func unpackVirtualRepository(s *schema.ResourceData) *v1.VirtualRepository {
 	repo.RepoLayoutRef = d.getStringRef("repo_layout_ref", false)
 	repo.DebianTrivialLayout = d.getBoolRef("debian_trivial_layout", false)
 	repo.ArtifactoryRequestsCanRetrieveRemoteArtifacts = d.getBoolRef("artifactory_requests_can_retrieve_remote_artifacts", false)
+	repo.VirtualRetrievalCachePeriodSecs =  d.getIntRef("virtual_retrieval_cache_period_seconds", false)
 	repo.Repositories = d.getListRef("repositories")
 	repo.Description = d.getStringRef("description", false)
 	repo.Notes = d.getStringRef("notes", false)
@@ -119,6 +125,7 @@ func packVirtualRepository(repo *v1.VirtualRepository, d *schema.ResourceData) e
 	logErr(d.Set("repo_layout_ref", repo.RepoLayoutRef))
 	logErr(d.Set("debian_trivial_layout", repo.DebianTrivialLayout))
 	logErr(d.Set("artifactory_requests_can_retrieve_remote_artifacts", repo.ArtifactoryRequestsCanRetrieveRemoteArtifacts))
+	logErr(d.Set("virtual_retrieval_cache_period_seconds", repo.VirtualRetrievalCachePeriodSecs))
 	logErr(d.Set("key_pair", repo.KeyPair))
 	logErr(d.Set("pom_repository_references_cleanup_policy", repo.PomRepositoryReferencesCleanupPolicy))
 	logErr(d.Set("default_deployment_repo", repo.DefaultDeploymentRepo))

--- a/pkg/artifactory/resource_artifactory_virtual_repository_test.go
+++ b/pkg/artifactory/resource_artifactory_virtual_repository_test.go
@@ -97,6 +97,7 @@ resource "artifactory_virtual_repository" "foo" {
     excludes_pattern = "com/google/**"
 	artifactory_requests_can_retrieve_remote_artifacts = true
 	pom_repository_references_cleanup_policy = "discard_active_reference"
+	virtual_retrieval_cache_period_seconds = 100
 }
 `
 
@@ -119,6 +120,7 @@ func TestAccVirtualRepository_full(t *testing.T) {
 					resource.TestCheckResourceAttr("artifactory_virtual_repository.foo", "includes_pattern", "com/atlassian/**,cloud/atlassian/**"),
 					resource.TestCheckResourceAttr("artifactory_virtual_repository.foo", "excludes_pattern", "com/google/**"),
 					resource.TestCheckResourceAttr("artifactory_virtual_repository.foo", "pom_repository_references_cleanup_policy", "discard_active_reference"),
+					resource.TestCheckResourceAttr("artifactory_virtual_repository.foo", "virtual_retrieval_cache_period_seconds", 100),
 				),
 			},
 		},

--- a/website/docs/r/artifactory_virtual_repository.html.markdown
+++ b/website/docs/r/artifactory_virtual_repository.html.markdown
@@ -50,6 +50,7 @@ Arguments have a one to one mapping with the [JFrog API](https://www.jfrog.com/c
 * `key_pair` - (Optional)
 * `pom_repository_references_cleanup_policy` - (Optional)
 * `default_deployment_repo` - (Optional)
+* `virtual_retrieval_cache_period_seconds` - (Optional)
 
 ## Import
 


### PR DESCRIPTION
Actual API call is `virtualRetrievalCachePeriodSecs` associated with virtual repositories. But in UI configuration its available only in Helm virtual repositories under `Helm Settings` option as `Metadata Retrieval Cache Period (Sec)`.
Checked and verified on Artifactory Version 6.8.0 .