### PR TITLE
Update go.mod to reflect git.apache.org being unavailable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/atlassian/terraform-provider-artifactory
 
+replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
+
 require (
 	github.com/atlassian/go-artifactory/v2 v2.4.0
 	github.com/hashicorp/terraform v0.12.0


### PR DESCRIPTION
git.apache.org, an external dependency for thrift is no longer available. This causes the build to fail since this repository doesn't vendor modules. This change adds a replace to the mod file to update thrift to its new location.