### PR TITLE
datasources added: artifactory_file & artifactory_fileinfo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/atlassian/terraform-provider-artifactory
 
 require (
-	github.com/atlassian/go-artifactory/v2 v2.4.0
+	github.com/atlassian/go-artifactory/v2 v2.5.0
 	github.com/hashicorp/terraform v0.12.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,8 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/atlassian/go-artifactory/v2 v2.4.0 h1:qj2nlDREa8BB03a09BcE+bj7gwlj/VXuD2hBvV80PDM=
-github.com/atlassian/go-artifactory/v2 v2.4.0/go.mod h1:mMEbxu89yTyKev4mysL03aSioTEdZ8+08KuMGG7myUY=
+github.com/atlassian/go-artifactory/v2 v2.5.0 h1:NKs9kuGgb2Gj+pU+Y7BzFlx6D/e6P82zP3m/FJZpy40=
+github.com/atlassian/go-artifactory/v2 v2.5.0/go.mod h1:mMEbxu89yTyKev4mysL03aSioTEdZ8+08KuMGG7myUY=
 github.com/aws/aws-sdk-go v1.15.78/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3ATZkfNZeM=
 github.com/aws/aws-sdk-go v1.16.36/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.19.18 h1:Hb3+b9HCqrOrbAtFstUWg7H5TQ+/EcklJtE8VShVs8o=

--- a/pkg/artifactory/datasource_artifactory_file.go
+++ b/pkg/artifactory/datasource_artifactory_file.go
@@ -1,0 +1,202 @@
+package artifactory
+
+import (
+	"context"
+	"fmt"
+	"github.com/atlassian/go-artifactory/v2/artifactory"
+	"github.com/atlassian/go-artifactory/v2/artifactory/v1"
+	"github.com/hashicorp/terraform/helper/schema"
+	"os"
+	"io"
+    "crypto/sha256"
+    "encoding/hex"
+)
+
+func datasourceArtifactoryFile() *schema.Resource {
+	return &schema.Resource{
+		Create: nil,
+		Read:   resourceArtifactRead,
+		Update: nil,
+		Delete: nil,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"repository": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"path": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"created": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"last_modified": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"modified_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"last_updated": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"download_uri": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"mimetype": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"md5": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"sha1": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"sha256": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"output_path": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"force_overwrite": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func resourceArtifactRead(d *schema.ResourceData, m interface{}) error {
+	c := m.(*artifactory.Artifactory)
+
+	repository := d.Get("repository").(string)
+	path := d.Get("path").(string)
+	outputPath := d.Get("output_path").(string)
+	forceOverwrite := d.Get("force_overwrite").(bool)
+
+	fileInfo, _, err := c.V1.Artifacts.FileInfo(context.Background(), repository, path)
+	if err != nil {
+		return err
+	}
+
+	skip, err := SkipDownload(fileInfo, outputPath)
+	if err != nil && !forceOverwrite {
+		return err
+	}
+
+	if !skip {
+		outFile, err := os.Create(outputPath)
+		if err != nil {
+			return err
+		}
+
+		defer outFile.Close()
+		
+		fileInfo, _, err = c.V1.Artifacts.FileContents(context.Background(), repository, path, outFile)
+		if err != nil {
+			return err
+		}
+	} 
+
+	return packFileInfo(fileInfo, d)
+}
+
+func SkipDownload(fileInfo *v1.FileInfo, path string) (bool, error) {
+	const skip = true
+	const dontSkip = false
+
+	if path == "" {
+		// no path specified, nothing to download
+		return skip, nil
+	}
+
+	if FileExists(path) {
+		chks_matches, err := VerifySha256Checksum(path, *fileInfo.Checksums.Sha256)
+
+		if chks_matches {
+			return skip, nil
+		} else if err != nil {
+			return dontSkip, err
+		} else {
+			return dontSkip, fmt.Errorf("Local file differs from upstream version") 
+		}
+	} else {
+		return dontSkip, nil
+	}
+}
+
+func FileExists(path string) bool {
+    if _, err := os.Stat(path); err != nil {
+        if os.IsNotExist(err) {
+            return false
+        }
+    }
+    return true
+}
+
+func VerifySha256Checksum(path string, expectedSha256 string) (bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+	    return false, err
+	}
+	defer f.Close()
+
+	hasher := sha256.New()
+
+	if _, err := io.Copy(hasher, f); err != nil {
+	    return false, err
+	}
+
+	return hex.EncodeToString(hasher.Sum(nil)) == expectedSha256, nil
+}
+
+func packFileInfo(fileInfo *v1.FileInfo, d *schema.ResourceData) error {
+	hasErr := false
+	logErr := cascadingErr(&hasErr)
+
+	d.SetId(*fileInfo.DownloadUri)
+
+	logErr(d.Set("created", *fileInfo.Created))
+	logErr(d.Set("created_by", *fileInfo.CreatedBy))
+	logErr(d.Set("last_modified", *fileInfo.LastModified))
+	logErr(d.Set("modified_by", *fileInfo.ModifiedBy))
+	logErr(d.Set("last_updated", *fileInfo.LastUpdated))
+	logErr(d.Set("download_uri", *fileInfo.DownloadUri))
+	logErr(d.Set("mimetype", *fileInfo.MimeType))
+	logErr(d.Set("size", *fileInfo.Size))
+
+	if fileInfo.Checksums != nil {
+		logErr(d.Set("md5", *fileInfo.Checksums.Md5))
+		logErr(d.Set("sha1", *fileInfo.Checksums.Sha1))
+		logErr(d.Set("sha256", *fileInfo.Checksums.Sha256))
+	}
+
+	if hasErr {
+		return fmt.Errorf("failed to pack fileInfo")
+	}
+
+	return nil
+}

--- a/pkg/artifactory/datasource_artifactory_file.go
+++ b/pkg/artifactory/datasource_artifactory_file.go
@@ -12,10 +12,10 @@ import (
 	"os"
 )
 
-func datasourceArtifactoryFile() *schema.Resource {
+func dataSourceArtifactoryFile() *schema.Resource {
 	return &schema.Resource{
 		Create: nil,
-		Read:   resourceArtifactRead,
+		Read:   dataSourceArtifactRead,
 		Update: nil,
 		Delete: nil,
 
@@ -89,7 +89,7 @@ func datasourceArtifactoryFile() *schema.Resource {
 	}
 }
 
-func resourceArtifactRead(d *schema.ResourceData, m interface{}) error {
+func dataSourceArtifactRead(d *schema.ResourceData, m interface{}) error {
 	c := m.(*artifactory.Artifactory)
 
 	repository := d.Get("repository").(string)

--- a/pkg/artifactory/datasource_artifactory_file.go
+++ b/pkg/artifactory/datasource_artifactory_file.go
@@ -2,14 +2,14 @@ package artifactory
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"github.com/atlassian/go-artifactory/v2/artifactory"
 	"github.com/atlassian/go-artifactory/v2/artifactory/v1"
 	"github.com/hashicorp/terraform/helper/schema"
-	"os"
 	"io"
-    "crypto/sha256"
-    "encoding/hex"
+	"os"
 )
 
 func datasourceArtifactoryFile() *schema.Resource {
@@ -114,12 +114,12 @@ func resourceArtifactRead(d *schema.ResourceData, m interface{}) error {
 		}
 
 		defer outFile.Close()
-		
+
 		fileInfo, _, err = c.V1.Artifacts.FileContents(context.Background(), repository, path, outFile)
 		if err != nil {
 			return err
 		}
-	} 
+	}
 
 	return packFileInfo(fileInfo, d)
 }
@@ -141,7 +141,7 @@ func SkipDownload(fileInfo *v1.FileInfo, path string) (bool, error) {
 		} else if err != nil {
 			return dontSkip, err
 		} else {
-			return dontSkip, fmt.Errorf("Local file differs from upstream version") 
+			return dontSkip, fmt.Errorf("Local file differs from upstream version")
 		}
 	} else {
 		return dontSkip, nil
@@ -149,25 +149,25 @@ func SkipDownload(fileInfo *v1.FileInfo, path string) (bool, error) {
 }
 
 func FileExists(path string) bool {
-    if _, err := os.Stat(path); err != nil {
-        if os.IsNotExist(err) {
-            return false
-        }
-    }
-    return true
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+	}
+	return true
 }
 
 func VerifySha256Checksum(path string, expectedSha256 string) (bool, error) {
 	f, err := os.Open(path)
 	if err != nil {
-	    return false, err
+		return false, err
 	}
 	defer f.Close()
 
 	hasher := sha256.New()
 
 	if _, err := io.Copy(hasher, f); err != nil {
-	    return false, err
+		return false, err
 	}
 
 	return hex.EncodeToString(hasher.Sum(nil)) == expectedSha256, nil

--- a/pkg/artifactory/datasource_artifactory_file.go
+++ b/pkg/artifactory/datasource_artifactory_file.go
@@ -14,7 +14,7 @@ import (
 
 func dataSourceArtifactoryFile() *schema.Resource {
 	return &schema.Resource{
-		Read:   dataSourceArtifactRead,
+		Read: dataSourceArtifactRead,
 
 		Schema: map[string]*schema.Schema{
 			"repository": {

--- a/pkg/artifactory/datasource_artifactory_file.go
+++ b/pkg/artifactory/datasource_artifactory_file.go
@@ -14,7 +14,7 @@ import (
 
 func dataSourceArtifactoryFile() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceArtifactRead,
+		Read: dataSourceFileRead,
 
 		Schema: map[string]*schema.Schema{
 			"repository": {
@@ -71,7 +71,7 @@ func dataSourceArtifactoryFile() *schema.Resource {
 			},
 			"output_path": {
 				Type:     schema.TypeString,
-				Optional: true,
+				Required: true,
 			},
 			"force_overwrite": {
 				Type:     schema.TypeBool,
@@ -82,7 +82,7 @@ func dataSourceArtifactoryFile() *schema.Resource {
 	}
 }
 
-func dataSourceArtifactRead(d *schema.ResourceData, m interface{}) error {
+func dataSourceFileRead(d *schema.ResourceData, m interface{}) error {
 	c := m.(*artifactory.Artifactory)
 
 	repository := d.Get("repository").(string)
@@ -164,32 +164,4 @@ func VerifySha256Checksum(path string, expectedSha256 string) (bool, error) {
 	}
 
 	return hex.EncodeToString(hasher.Sum(nil)) == expectedSha256, nil
-}
-
-func packFileInfo(fileInfo *v1.FileInfo, d *schema.ResourceData) error {
-	hasErr := false
-	logErr := cascadingErr(&hasErr)
-
-	d.SetId(*fileInfo.DownloadUri)
-
-	logErr(d.Set("created", *fileInfo.Created))
-	logErr(d.Set("created_by", *fileInfo.CreatedBy))
-	logErr(d.Set("last_modified", *fileInfo.LastModified))
-	logErr(d.Set("modified_by", *fileInfo.ModifiedBy))
-	logErr(d.Set("last_updated", *fileInfo.LastUpdated))
-	logErr(d.Set("download_uri", *fileInfo.DownloadUri))
-	logErr(d.Set("mimetype", *fileInfo.MimeType))
-	logErr(d.Set("size", *fileInfo.Size))
-
-	if fileInfo.Checksums != nil {
-		logErr(d.Set("md5", *fileInfo.Checksums.Md5))
-		logErr(d.Set("sha1", *fileInfo.Checksums.Sha1))
-		logErr(d.Set("sha256", *fileInfo.Checksums.Sha256))
-	}
-
-	if hasErr {
-		return fmt.Errorf("failed to pack fileInfo")
-	}
-
-	return nil
 }

--- a/pkg/artifactory/datasource_artifactory_file.go
+++ b/pkg/artifactory/datasource_artifactory_file.go
@@ -14,14 +14,7 @@ import (
 
 func dataSourceArtifactoryFile() *schema.Resource {
 	return &schema.Resource{
-		Create: nil,
 		Read:   dataSourceArtifactRead,
-		Update: nil,
-		Delete: nil,
-
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
 
 		Schema: map[string]*schema.Schema{
 			"repository": {

--- a/pkg/artifactory/datasource_artifactory_file_test.go
+++ b/pkg/artifactory/datasource_artifactory_file_test.go
@@ -1,0 +1,91 @@
+package artifactory
+
+import (
+	"testing"
+    "io/ioutil"
+    "os"
+	"github.com/stretchr/testify/assert"
+	"github.com/atlassian/go-artifactory/v2/artifactory/v1"
+	"path/filepath"
+)
+
+func TestSkipDownload(t *testing.T) {
+	const testString = "test content"
+	const expectedSha256 = "6ae8a75555209fd6c44157c0aed8016e763ff435a19cf186f76863140143ff72"
+
+	file, err := CreateTempFile(testString)
+
+	assert.Nil(t, err)
+
+	defer CloseAndRemove(file)
+
+	existingPath, _ := filepath.Abs(file.Name())
+	nonExistingPath := existingPath + "-doesnt-exist"
+
+	sha256 := expectedSha256
+	fileInfo := new(v1.FileInfo)
+	fileInfo.Checksums = new(v1.Checksums)
+	fileInfo.Checksums.Sha256 = &sha256
+
+	skip, err := SkipDownload(fileInfo, existingPath)
+	assert.Equal(t, true, skip) // file exists, checksum matches => skip
+	assert.Nil(t, err)
+
+	skip, err = SkipDownload(fileInfo, nonExistingPath)
+	assert.Equal(t, false, skip) // file doesn't exist => dont skip
+	assert.Nil(t, err)
+
+	sha256 = "6666666666666666666666666666666666666666666666666666666666666666"
+	fileInfo.Checksums.Sha256 = &sha256
+
+	skip, err = SkipDownload(fileInfo, existingPath)
+	assert.Equal(t, false, skip) // file exists, checksum doesnt match => dont skip & err
+	assert.NotNil(t, err)
+}
+
+func TestFileExists(t *testing.T) {
+	tmpFile, err := CreateTempFile("test")
+
+	assert.Nil(t, err)
+
+    defer CloseAndRemove(tmpFile)
+
+    existingPath, _ := filepath.Abs(tmpFile.Name())
+    nonExistingPath := existingPath + "-doesnt-exist"
+
+   	assert.Equal(t, true, FileExists(existingPath))
+   	assert.Equal(t, false, FileExists(nonExistingPath))
+}
+
+func TestVerifySha256Checksum(t *testing.T) {
+	const testString = "test content"
+	const expectedSha256 = "6ae8a75555209fd6c44157c0aed8016e763ff435a19cf186f76863140143ff72"
+
+	file, err := CreateTempFile(testString)
+
+	assert.Nil(t, err)
+
+	defer CloseAndRemove(file)
+
+	filePath, _ := filepath.Abs(file.Name())
+
+	sha256Verified, err := VerifySha256Checksum(filePath, expectedSha256)
+
+	assert.Nil(t, err)
+	assert.Equal(t, true, sha256Verified)
+}
+
+func CreateTempFile(content string) (f *os.File, err error) {
+	file, err := ioutil.TempFile(os.TempDir(), "terraform-provider-artifactory-")
+
+	if content != "" {
+		file.WriteString(content)
+	}
+
+	return file, err
+}
+
+func CloseAndRemove(f *os.File) {
+	f.Close()
+	os.Remove(f.Name())
+}

--- a/pkg/artifactory/datasource_artifactory_file_test.go
+++ b/pkg/artifactory/datasource_artifactory_file_test.go
@@ -1,12 +1,12 @@
 package artifactory
 
 import (
-	"testing"
-    "io/ioutil"
-    "os"
-	"github.com/stretchr/testify/assert"
 	"github.com/atlassian/go-artifactory/v2/artifactory/v1"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"os"
 	"path/filepath"
+	"testing"
 )
 
 func TestSkipDownload(t *testing.T) {
@@ -48,13 +48,13 @@ func TestFileExists(t *testing.T) {
 
 	assert.Nil(t, err)
 
-    defer CloseAndRemove(tmpFile)
+	defer CloseAndRemove(tmpFile)
 
-    existingPath, _ := filepath.Abs(tmpFile.Name())
-    nonExistingPath := existingPath + "-doesnt-exist"
+	existingPath, _ := filepath.Abs(tmpFile.Name())
+	nonExistingPath := existingPath + "-doesnt-exist"
 
-   	assert.Equal(t, true, FileExists(existingPath))
-   	assert.Equal(t, false, FileExists(nonExistingPath))
+	assert.Equal(t, true, FileExists(existingPath))
+	assert.Equal(t, false, FileExists(nonExistingPath))
 }
 
 func TestVerifySha256Checksum(t *testing.T) {

--- a/pkg/artifactory/datasource_artifactory_file_test.go
+++ b/pkg/artifactory/datasource_artifactory_file_test.go
@@ -1,47 +1,12 @@
 package artifactory
 
 import (
-	"github.com/atlassian/go-artifactory/v2/artifactory/v1"
 	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 )
-
-func TestSkipDownload(t *testing.T) {
-	const testString = "test content"
-	const expectedSha256 = "6ae8a75555209fd6c44157c0aed8016e763ff435a19cf186f76863140143ff72"
-
-	file, err := CreateTempFile(testString)
-
-	assert.Nil(t, err)
-
-	defer CloseAndRemove(file)
-
-	existingPath, _ := filepath.Abs(file.Name())
-	nonExistingPath := existingPath + "-doesnt-exist"
-
-	sha256 := expectedSha256
-	fileInfo := new(v1.FileInfo)
-	fileInfo.Checksums = new(v1.Checksums)
-	fileInfo.Checksums.Sha256 = &sha256
-
-	skip, err := SkipDownload(fileInfo, existingPath)
-	assert.Equal(t, true, skip) // file exists, checksum matches => skip
-	assert.Nil(t, err)
-
-	skip, err = SkipDownload(fileInfo, nonExistingPath)
-	assert.Equal(t, false, skip) // file doesn't exist => dont skip
-	assert.Nil(t, err)
-
-	sha256 = "6666666666666666666666666666666666666666666666666666666666666666"
-	fileInfo.Checksums.Sha256 = &sha256
-
-	skip, err = SkipDownload(fileInfo, existingPath)
-	assert.Equal(t, false, skip) // file exists, checksum doesnt match => dont skip & err
-	assert.NotNil(t, err)
-}
 
 func TestFileExists(t *testing.T) {
 	tmpFile, err := CreateTempFile("test")

--- a/pkg/artifactory/datasource_artifactory_fileinfo.go
+++ b/pkg/artifactory/datasource_artifactory_fileinfo.go
@@ -1,0 +1,112 @@
+package artifactory
+
+import (
+	"context"
+	"fmt"
+	"github.com/atlassian/go-artifactory/v2/artifactory"
+	"github.com/atlassian/go-artifactory/v2/artifactory/v1"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceArtifactoryFileInfo() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceFileInfoRead,
+
+		Schema: map[string]*schema.Schema{
+			"repository": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"path": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"created": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"last_modified": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"modified_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"last_updated": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"download_uri": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"mimetype": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"md5": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"sha1": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"sha256": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceFileInfoRead(d *schema.ResourceData, m interface{}) error {
+	c := m.(*artifactory.Artifactory)
+
+	repository := d.Get("repository").(string)
+	path := d.Get("path").(string)
+
+	fileInfo, _, err := c.V1.Artifacts.FileInfo(context.Background(), repository, path)
+	if err != nil {
+		return err
+	}
+
+	return packFileInfo(fileInfo, d)
+}
+
+func packFileInfo(fileInfo *v1.FileInfo, d *schema.ResourceData) error {
+	hasErr := false
+	logErr := cascadingErr(&hasErr)
+
+	d.SetId(*fileInfo.DownloadUri)
+
+	logErr(d.Set("created", *fileInfo.Created))
+	logErr(d.Set("created_by", *fileInfo.CreatedBy))
+	logErr(d.Set("last_modified", *fileInfo.LastModified))
+	logErr(d.Set("modified_by", *fileInfo.ModifiedBy))
+	logErr(d.Set("last_updated", *fileInfo.LastUpdated))
+	logErr(d.Set("download_uri", *fileInfo.DownloadUri))
+	logErr(d.Set("mimetype", *fileInfo.MimeType))
+	logErr(d.Set("size", *fileInfo.Size))
+
+	if fileInfo.Checksums != nil {
+		logErr(d.Set("md5", *fileInfo.Checksums.Md5))
+		logErr(d.Set("sha1", *fileInfo.Checksums.Sha1))
+		logErr(d.Set("sha256", *fileInfo.Checksums.Sha256))
+	}
+
+	if hasErr {
+		return fmt.Errorf("failed to pack fileInfo")
+	}
+
+	return nil
+}

--- a/pkg/artifactory/provider.go
+++ b/pkg/artifactory/provider.go
@@ -73,7 +73,8 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"artifactory_file": dataSourceArtifactoryFile(),
+			"artifactory_file":     dataSourceArtifactoryFile(),
+			"artifactory_fileinfo": dataSourceArtifactoryFileInfo(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/pkg/artifactory/provider.go
+++ b/pkg/artifactory/provider.go
@@ -72,6 +72,10 @@ func Provider() terraform.ResourceProvider {
 			"artifactory_permission_targets": resourceArtifactoryPermissionTargets(),
 		},
 
+		DataSourcesMap: map[string]*schema.Resource{
+			"artifactory_file": 					 datasourceArtifactoryFile(),
+		},
+
 		ConfigureFunc: providerConfigure,
 	}
 }

--- a/pkg/artifactory/provider.go
+++ b/pkg/artifactory/provider.go
@@ -73,7 +73,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"artifactory_file": datasourceArtifactoryFile(),
+			"artifactory_file": dataSourceArtifactoryFile(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/pkg/artifactory/provider.go
+++ b/pkg/artifactory/provider.go
@@ -73,7 +73,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"artifactory_file": 					 datasourceArtifactoryFile(),
+			"artifactory_file": datasourceArtifactoryFile(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -23,6 +23,10 @@ with the proper credentials before it can be used.
     * [Virtual Repositories](./r/artifactory_virtual_repository.html.markdown)
     * [Certificates](./r/artifactory_certificate.html.markdown)
 
+- Available Datasources
+    * [File](./r/artifactory_file.html.markdown)
+    * [FileInfo](./r/artifactory_fileinfo.html.markdown)
+
 - Deprecated Resources
     * [Permission Targets (V1 API)](./r/artifactory_permission_target_v1.html.markdown)
 

--- a/website/docs/r/artifactory_file.html.markdown
+++ b/website/docs/r/artifactory_file.html.markdown
@@ -1,0 +1,47 @@
+---
+layout: "artifactory"
+page_title: "Artifactory: artifactory_file"
+sidebar_current: "docs-artifactory-datasource-file"
+description: |-
+  Provides a file datasource.
+---
+
+# artifactory_file
+
+Provides an Artifactory file datasource. This can be used to download a file from a given Artifactory repository.
+
+## Example Usage
+
+```hcl
+# 
+data "artifactory_file" "my-file" {
+   repository = "repo-key"
+   path = "/path/to/the/artifact.zip"
+   output_path = "tmp/artifact.zip"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `repository` - (Required) Name of the repository where the file is stored.
+* `path` - (Required) The path to the file within the repository.
+* `output_path` - (Required) The local path the file should be downloaded to.
+* `force_overwrite` - (Optional) If set to true, an existing file in the output_path will be overwritten. Default: false
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `created` - The time & date when the file was created.
+* `created_by` - The user who created the file.
+* `last_modified` - The time & date when the file was last modified.
+* `modified_by` - The user who last modified the file.
+* `last_updated` - The time & date when the file was last updated.
+* `mimetype` - The mimetype of the file.
+* `size` - The size of the file.
+* `download_uri` - The URI that can be used to download the file.
+* `md5` - MD5 checksum of the file.
+* `sha1` - SHA1 checksum of the file.
+* `sha256` - SHA256 checksum of the file.

--- a/website/docs/r/artifactory_fileinfo.html.markdown
+++ b/website/docs/r/artifactory_fileinfo.html.markdown
@@ -1,0 +1,44 @@
+---
+layout: "artifactory"
+page_title: "Artifactory: artifactory_fileinfo"
+sidebar_current: "docs-artifactory-datasource-fileinfo"
+description: |-
+  Provides a fileinfo datasource.
+---
+
+# artifactory_fileinfo
+
+Provides an Artifactory fileinfo datasource. This can be used to read metadata of files stored in Artifactory repositories.
+
+## Example Usage
+
+```hcl
+# 
+data "artifactory_fileinfo" "my-file" {
+   repository = "repo-key"
+   path = "/path/to/the/artifact.zip" 
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `repository` - (Required) Name of the repository where the file is stored.
+* `path` - (Required) The path to the file within the repository.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `created` - The time & date when the file was created.
+* `created_by` - The user who created the file.
+* `last_modified` - The time & date when the file was last modified.
+* `modified_by` - The user who last modified the file.
+* `last_updated` - The time & date when the file was last updated.
+* `mimetype` - The mimetype of the file.
+* `size` - The size of the file.
+* `download_uri` - The URI that can be used to download the file.
+* `md5` - MD5 checksum of the file.
+* `sha1` - SHA1 checksum of the file.
+* `sha256` - SHA256 checksum of the file.


### PR DESCRIPTION
This PR implements https://github.com/atlassian/terraform-provider-artifactory/issues/63, means it will add support to download artifacts using terraform. It won't compile as long as https://github.com/atlassian/go-artifactory/pull/19 is not merged.

Best,
Chris

```hcl
provider "artifactory" { ... } # this is up to you

data "artifactory_file" "test" {
   # required - the repository key
   repository = "repo-key" 

   # required - the path to the artifact within the repo
   path = "/path/to/the/artifact.zip" 

   # optional (default: empty)   - if set terraform will download the artifact to the specified output_path, if nil only the metadata (see below) are accessible
   output_path = "artifact.zip"

   # optional (default: false) - if true, terraform will overwrite the existing file specified via output_path
   force_overwrite = true                                                                 
}

output "created" {
  value = data.artifactory_file.test.created_by
}

output "created_by" {
  value = data.artifactory_file.test.created_by
}

output "last_modified" {
  value = data.artifactory_file.test.last_modified
}

output "modified_by" {
  value = data.artifactory_file.test.modified_by
}

output "last_updated" {
  value = data.artifactory_file.test.last_updated
}

output "mimetype" {
  value = data.artifactory_file.test.mimetype
}

output "size" {
  value = data.artifactory_file.test.size
}

output "uri" {
  value = data.artifactory_file.test.download_uri
}

output "md5" {
  value = data.artifactory_file.test.md5
}

output "sha1" {
  value = data.artifactory_file.test.sha1
}

output "sha256" {
  value = data.artifactory_file.test.sha256
}

output "output_path" {
  value = data.artifactory_file.test.output_path
}
```