### PR TITLE
Add resource: api_key

### DIFF
--- a/pkg/artifactory/provider.go
+++ b/pkg/artifactory/provider.go
@@ -68,6 +68,7 @@ func Provider() terraform.ResourceProvider {
 			"artifactory_replication_config":        resourceArtifactoryReplicationConfig(),
 			"artifactory_single_replication_config": resourceArtifactorySingleReplicationConfig(),
 			"artifactory_certificate":               resourceArtifactoryCertificate(),
+			"artifactory_api_key":                   resourceArtifactoryApiKey(),
 			// Deprecated. Remove in V3
 			"artifactory_permission_targets": resourceArtifactoryPermissionTargets(),
 		},

--- a/pkg/artifactory/resource_artifactory_api_key.go
+++ b/pkg/artifactory/resource_artifactory_api_key.go
@@ -1,0 +1,90 @@
+package artifactory
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/atlassian/go-artifactory/v2/artifactory"
+	v1 "github.com/atlassian/go-artifactory/v2/artifactory/v1"
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceArtifactoryApiKey() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceApiKeyCreate,
+		Read:   resourceApiKeyRead,
+		Delete: resourceApiKeyDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"api_key": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+func unpackApiKey(s *schema.ResourceData) *v1.ApiKey {
+	d := &ResourceData{s}
+	apiKey := new(v1.ApiKey)
+	apiKey.ApiKey = d.getStringRef("api_key", false)
+
+	return apiKey
+}
+
+func packApiKey(apiKey *v1.ApiKey, d *schema.ResourceData) error {
+	hasErr := false
+	logErr := cascadingErr(&hasErr)
+
+	logErr(d.Set("api_key", apiKey.ApiKey))
+
+	if hasErr {
+		return fmt.Errorf("failed to pack api key")
+	}
+
+	return nil
+}
+
+func resourceApiKeyCreate(d *schema.ResourceData, m interface{}) error {
+	c := m.(*artifactory.Artifactory)
+
+	apiKey, _, err := c.V1.Security.CreateApiKey(context.Background())
+	if err != nil {
+		return err
+	}
+
+	d.SetId(strconv.Itoa(hashcode.String(*apiKey.ApiKey)))
+	return resourceApiKeyRead(d, m)
+}
+
+func resourceApiKeyRead(d *schema.ResourceData, m interface{}) error {
+	c := m.(*artifactory.Artifactory)
+
+	apiKey, resp, err := c.V1.Security.GetApiKey(context.Background())
+	if resp.StatusCode == http.StatusNotFound {
+		d.SetId("")
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	return packApiKey(apiKey, d)
+}
+
+func resourceApiKeyDelete(d *schema.ResourceData, m interface{}) error {
+	c := m.(*artifactory.Artifactory)
+	_, resp, err := c.V1.Security.RevokeApiKey(context.Background())
+	if resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
+
+	return err
+}

--- a/pkg/artifactory/resource_artifactory_api_key_test.go
+++ b/pkg/artifactory/resource_artifactory_api_key_test.go
@@ -1,0 +1,53 @@
+package artifactory
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/atlassian/go-artifactory/v2/artifactory"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+const apiKey = `
+resource "artifactory_api_key" "foobar" {}
+`
+
+func TestAccApiKey(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckApiKeyDestroy("artifactory_api_key.foobar"),
+		Providers:    testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: apiKey,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("artifactory_api_key", "api_key"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckApiKeyDestroy(id string) func(*terraform.State) error {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*artifactory.Artifactory)
+		rs, ok := s.RootModule().Resources[id]
+
+		if !ok {
+			return fmt.Errorf("err: Resource id[%s] not found", id)
+		}
+
+		_, resp, err := client.V1.Security.GetApiKey(context.Background())
+
+		if resp.StatusCode == http.StatusNotFound {
+			return nil
+		} else if err != nil {
+			return fmt.Errorf("error: Request failed: %s", err.Error())
+		} else {
+			return fmt.Errorf("error: API key %s still exists", rs.Primary.ID)
+		}
+	}
+}

--- a/pkg/artifactory/resource_artifactory_api_key_test.go
+++ b/pkg/artifactory/resource_artifactory_api_key_test.go
@@ -3,7 +3,6 @@ package artifactory
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"testing"
 
 	"github.com/atlassian/go-artifactory/v2/artifactory"
@@ -24,7 +23,7 @@ func TestAccApiKey(t *testing.T) {
 			{
 				Config: apiKey,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("artifactory_api_key", "api_key"),
+					resource.TestCheckResourceAttrSet("artifactory_api_key.foobar", "api_key"),
 				),
 			},
 		},
@@ -40,14 +39,14 @@ func testAccCheckApiKeyDestroy(id string) func(*terraform.State) error {
 			return fmt.Errorf("err: Resource id[%s] not found", id)
 		}
 
-		_, resp, err := client.V1.Security.GetApiKey(context.Background())
+		key, _, err := client.V1.Security.GetApiKey(context.Background())
 
-		if resp.StatusCode == http.StatusNotFound {
-			return nil
-		} else if err != nil {
+		if err != nil {
 			return fmt.Errorf("error: Request failed: %s", err.Error())
-		} else {
+		} else if key.ApiKey != nil {
 			return fmt.Errorf("error: API key %s still exists", rs.Primary.ID)
 		}
+
+		return nil
 	}
 }

--- a/website/docs/r/artifactory_api_key.html.markdown
+++ b/website/docs/r/artifactory_api_key.html.markdown
@@ -1,0 +1,36 @@
+---
+layout: "artifactory"
+page_title: "Artifactory: artifactory_api_key"
+sidebar_current: "docs-artifactory-resource-api-key"
+description: |-
+  Provides an API key resource.
+---
+
+# artifactory_api_key
+
+Provides an Artifactory API key resource. This can be used to create and manage Artifactory API keys.
+
+~> **Note:** API keys will be stored in the raw state as plain-text. [Read more about sensitive data in
+state](https://www.terraform.io/docs/state/sensitive-data.html).
+
+
+## Example Usage
+
+```hcl
+# Create a new Artifactory API key for the configured user
+resource "artifactory_api_key" "ci" {}
+```
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `api_key` - The API key.
+
+## Import
+
+A user's API key can be imported using any identifier, e.g.
+
+```
+$ terraform import artifactory_api_key.test import
+```


### PR DESCRIPTION
Adds an `artifactory_api_key` resource for managing API keys. This allows a user to generate an initial set of credentials for Terraform and then combine `artifactory_user` and `artifactory_api_key` to provision additional users/keys for other systems.

This is particularly important for organizations that require encrypted passwords, meaning the user's password cannot be used in package clients:

https://www.jfrog.com/confluence/display/JFROG/Centrally+Secure+Passwords