### PR TITLE
Fix examples for Terraform 0.12

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -32,6 +32,16 @@ with the proper credentials before it can be used.
 
 ## Example Usage
 ```hcl
+# Required for [Terraform 0.13](https://www.terraform.io/upgrade-guides/0-13.html)
+terraform {
+  required_providers {
+    artifactory = {
+      source  = "terraform.example.com/atlassian/artifactory"
+      version = "2.0.0"
+    }
+  }
+}
+
 # Configure the Artifactory provider
 provider "artifactory" {
   url = "${var.artifactory_url}"

--- a/website/docs/r/artifactory_permission_target.html.markdown
+++ b/website/docs/r/artifactory_permission_target.html.markdown
@@ -19,38 +19,33 @@ Provides an Artifactory permission target resource. This can be used to create a
 resource "artifactory_permission_target" "test-perm" {
   name = "test-perm"
 
-  repo = {
+  repo {
     includes_pattern = ["foo/**"]
     excludes_pattern = ["bar/**"]
     repositories     = ["example-repo-local"]
 
-    actions = {
-      users = [
-        {
-          name        = "anonymous"
-          permissions = ["read", "write"]
-        },
-      ]
+    actions {
+      users {
+        name        = "anonymous"
+        permissions = ["read", "write"]
+      }
 
-      groups = [
-        {
-          name        = "readers"
-          permissions = ["read"]
-        },
-      ]
+      groups {
+        name        = "readers"
+        permissions = ["read"]
+      }
     }
   }
 
-  build = {
+  build {
+    includes_pattern = ["**"]
     repositories     = ["artifactory-build-info"]
 
-    actions = {
-      users = [
-        {
-          name        = "anonymous"
-          permissions = ["read", "write"]
-        },
-      ]
+    actions {
+      users {
+        name        = "anonymous"
+        permissions = ["read", "write"]
+      }
     }
   }
 }
@@ -76,50 +71,4 @@ Permission targets can be imported using their name, e.g.
 
 ```
 $ terraform import artifactory_permission_target.terraform-test-permission mypermission
-```
-
-
-Provides an Artifactory permission target resource. This can be used to create and manage Artifactory permission targets.
-
-## Example Usage
-
-```hcl
-# Create a new Artifactory permission target called testpermission
-resource "artifactory_permission_targets" "terraform-test-permission" {
-  name          = "testpermission"
-  repositories = ["myrepo"]
-  users = [
-    {
-      name = "test_user"
-      permissions = ["r", "w"]
-    }
-  ]
-  groups = [
-    {
-      name        = "readers"
-      permissions = ["r"]
-    }
-  ]
-}
-```
-
-## Argument Reference
-
-The following arguments are supported:
-
-* `name` - (Required) Name of permission
-* `includes_pattern` - (Optional) Pattern of artifacts to include
-* `excludes_pattern` - (Optional) Pattern of artifacts to exclude
-* `repositories` - (Optional) List of repositories this permission target is applicable for
-* `users` - (Optional) Users this permission target applies for. 
-* `groups` - (Optional) Groups this permission applies for. 
-
-The permissions can be set to a combination of m=admin; d=delete; w=deploy; n=annotate; r=read
-
-## Import
-
-Permission targets can be imported using their name, e.g.
-
-```
-$ terraform import artifactory_permission_targets.terraform-test-permission mypermission
 ```

--- a/website/docs/r/artifactory_permission_target_v1.html.markdown
+++ b/website/docs/r/artifactory_permission_target_v1.html.markdown
@@ -19,18 +19,14 @@ Provides an Artifactory permission target resource. This can be used to create a
 resource "artifactory_permission_targets" "terraform-test-permission" {
   name          = "testpermission"
   repositories = ["myrepo"]
-  users = [
-    {
-      name = "test_user"
-      permissions = ["r", "w"]
-    }
-  ]
-  groups = [
-    {
-      name        = "readers"
-      permissions = ["r"]
-    }
-  ]
+  users {
+    name = "test_user"
+    permissions = ["r", "w"]
+  }
+  groups {
+    name        = "readers"
+    permissions = ["r"]
+  }
 }
 ```
 

--- a/website/docs/r/artifactory_replication_config.html.markdown
+++ b/website/docs/r/artifactory_replication_config.html.markdown
@@ -41,13 +41,11 @@ resource "artifactory_replication_config" "foo-rep" {
 	cron_exp = "0 0 * * * ?"
 	enable_event_replication = true
 	
-	replications = [
-		{
-			url = "$var.artifactory_url"
-			username = "$var.artifactory_username"
-			password = "$var.artifactory_password"
-		}
-	]
+	replications {
+		url = "$var.artifactory_url"
+		username = "$var.artifactory_username"
+		password = "$var.artifactory_password"
+	}
 }
 ```
 


### PR DESCRIPTION
Update map declarations in the documentation examples (permission and replication configs, specifically) to work in Terraform 0.12, as described in issue #48.

Add a snippet into the documentation example usage, which is required by Terraform 0.13 to import the provider.

Remove the deprecated permission target documentation from the end of the regular permission target page, this appears to be duplicated there by mistake.